### PR TITLE
fix: enable AllowUserVairables=true when importing custom content

### DIFF
--- a/Source/ACE.Server/Program_DbUpdates.cs
+++ b/Source/ACE.Server/Program_DbUpdates.cs
@@ -193,7 +193,7 @@ namespace ACE.Server
                 {
                     Console.Write($"Searching for SQL files within {path} .... ");
 
-                    var sqlConnect = new MySqlConnector.MySqlConnection($"server={ConfigManager.Config.MySql.World.Host};port={ConfigManager.Config.MySql.World.Port};user={ConfigManager.Config.MySql.World.Username};password={ConfigManager.Config.MySql.World.Password};database={ConfigManager.Config.MySql.World.Database};DefaultCommandTimeout=120;SslMode=None;AllowPublicKeyRetrieval=true");
+                    var sqlConnect = new MySqlConnector.MySqlConnection($"server={ConfigManager.Config.MySql.World.Host};port={ConfigManager.Config.MySql.World.Port};user={ConfigManager.Config.MySql.World.Username};password={ConfigManager.Config.MySql.World.Password};database={ConfigManager.Config.MySql.World.Database};DefaultCommandTimeout=120;SslMode=None;AllowPublicKeyRetrieval=true;AllowUserVariables=true");
                     foreach (var file in contentDI.GetFiles("*.sql", content_folders_search_option).OrderBy(f => f.FullName))
                     {
                         Console.Write($"Found {file.FullName} .... ");


### PR DESCRIPTION
* For some reason mysql will not import custom content correctly in linux environments without setting this to true