### PR TITLE
fix: remove dead code from dekaru merge

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -324,14 +324,6 @@ namespace ACE.Server.WorldObjects
 
             TryShuffleStance(wieldedLocation);
 
-            // handle item spells
-            if (item.ItemCurMana > 0 || item is LeyLineAmulet)
-                TryActivateSpells(item);
-
-            // handle equipment sets
-            if (item.HasItemSet)
-                EquipItemFromSet(item);
-
             return true;
         }
 


### PR DESCRIPTION
* dead code causing equipped item spells applying twice with duration