### PR TITLE
chore: update server properties

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -929,6 +929,20 @@ namespace ACE.Server.Managers
                     if (SEASON4_PATCH_1_9)
                     {
                         PropertyManager.ModifyLong("player_corpse_permissible_age", 7200);
+
+                        // Reason: Economy is too hard
+                        PropertyManager.ModifyDouble("coin_stack_multiplier", 1.0);
+                        PropertyManager.ModifyDouble("spell_extraction_scroll_base_chance", 0.5);
+                        PropertyManager.ModifyDouble("spell_extraction_scroll_chance_per_extra_spell", 0.1);
+                        // Reason: Dekaru's Arcane Lore changes make this unnecessary to penalize people for
+                        PropertyManager.ModifyDouble("spelltransfer_over_tier_success_chance", 1.0);
+                        // Reason: More hot dungeons is good for the morale of the people
+                        PropertyManager.ModifyDouble("hot_dungeon_interval", 3600.0);
+                        PropertyManager.ModifyDouble("hot_dungeon_chance", 0.33);
+                        // Reason: Item loss is bad enough
+                        PropertyManager.ModifyDouble("extra_vitae_penalty_pvp", 0.0);
+                        // Reason: Global xp is already reduced by 25%, no need to keep quest xp reduced on top of it
+                        PropertyManager.ModifyDouble("quest_xp_modifier", 1.0);
                     }
                 }
             }


### PR DESCRIPTION
Here are the following reasons and their updated properties:

Reason: because the economy is too hard

* coin_stack_multiplier is now 1.0 (was 0.5)
* spell_extraction_scroll_base_chance is now 0.5 (was 0.25)
* spell_extraction_scroll_chance_per_extra_spell is now 0.1 (was 0.15)

Reason: Dekaru's Arcane Lore changes make this unnecessary to penalize people for

* spelltransfer_over_tier_success_chance is now 1.0 (was 0.5)

Reason: More hot dungeons is good for the morale of the people

* hot_dungeon_interval is now 3600 (was 7800)
* hot_dungeon_chance is now 0.33 (was 0.1)

Reason: Item loss is bad enough

* extra_vitae_penalty_pvp is now 0 (was 0.15)

Reason: Global xp is already reduced by 25%, no need to keep quest xp reduced on top of it

* quest_xp_modifier is now 1.0 (was 0.25)