### PR TITLE
refactor: updated exploration contracts/treasure

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -520,6 +520,7 @@ namespace ACE.Server.Managers
         public const bool SEASON4_PATCH_1_6 = true;
         public const bool SEASON4_PATCH_1_9 = true;
         public const bool SEASON4_PATCH_1_10 = true;
+        public const bool SEASON4_PATCH_1_16 = true;
 
         public static void LoadDefaultProperties()
         {
@@ -962,6 +963,14 @@ namespace ACE.Server.Managers
                         PropertyManager.ModifyDouble("mob_awareness_range", 1.0); // previously 1.25
                         // Reason: Value was relevent for the previous season, but not for this one
                         PropertyManager.ModifyDouble("salvage_amount_multiplier", 1.0); // previously 0.4
+                    }
+
+                    if (SEASON4_PATCH_1_16)
+                    {
+                        // Reason: Reaching exploration contract location still uses this modifier and it needs to be increased
+                        PropertyManager.ModifyDouble("exploration_bonus_xp", 0.5); // previously 0
+                        // Reason: New property for exploration contract treasure
+                        PropertyManager.ModifyDouble("exploration_bonus_xp_treasure", 0.5); 
                     }
                 }
             }
@@ -1517,6 +1526,7 @@ namespace ACE.Server.Managers
                 ("hot_dungeon_bonus_xp", new(1.0, "Extra xp earned for kills when inside hot dungeons. 1.0 means 100% more xp.")),
                 ("exploration_bonus_xp_markers", new(1.0, "Extra xp earned while completing exploration assignment's marker objectives. 1.0 means 100% more xp.")),
                 ("exploration_bonus_xp_kills", new(2.0, "Extra xp earned while completing exploration assignment's kill objectives. 1.0 means 100% more xp.")),
+                ("exploration_bonus_xp_treasure", new(0.5, "Extra xp earned while completing exploration treasure map hunting. 1.0 means 100% more xp.")),
 
                 ("elite_mob_spawn_rate", new(0.00, "Probability of a creature spawning as an elite mob. 1.0 means 100%")),
                 ("elite_mob_loot_quality", new(0.5, "Loot quality mod of elite mob (For reference, normal is 1.0, chests are 1.2, Awareness chests are 1.4")),

--- a/Source/ACE.Server/WorldObjects/GenericObject.cs
+++ b/Source/ACE.Server/WorldObjects/GenericObject.cs
@@ -65,7 +65,7 @@ namespace ACE.Server.WorldObjects
                     {
                         player.Exploration1MarkerProgressTracker--;
                         var msg = $"{player.Exploration1MarkerProgressTracker:N0} marker{(player.Exploration1MarkerProgressTracker != 1 ? "s" : "")} remaining.";
-                        player.EarnXP((int)(((-player.Level ?? -1) - 1000) * (PropertyManager.GetDouble("exploration_bonus_xp_markers").Item + 0.5)), XpType.Exploration, null, null, 0, null, ShareType.Fellowship, msg);
+                        player.EarnXP((-player.Level ?? -1) - 1000, XpType.Exploration, null, null, 0, null, ShareType.Fellowship, msg, PropertyManager.GetDouble("exploration_bonus_xp_markers").Item + 0.5);
 
                         if (player.Exploration1MarkerProgressTracker == 0)
                         {
@@ -83,7 +83,7 @@ namespace ACE.Server.WorldObjects
                     {
                         player.Exploration2MarkerProgressTracker--;
                         var msg = $"{player.Exploration2MarkerProgressTracker:N0} marker{(player.Exploration2MarkerProgressTracker != 1 ? "s" : "")} remaining.";
-                        player.EarnXP((int)(((-player.Level ?? -1) - 1000) * (PropertyManager.GetDouble("exploration_bonus_xp_markers").Item + 0.5)), XpType.Exploration, null, null, 0, null, ShareType.Fellowship, msg);
+                        player.EarnXP((-player.Level ?? -1) - 1000, XpType.Exploration, null, null, 0, null, ShareType.Fellowship, msg, PropertyManager.GetDouble("exploration_bonus_xp_markers").Item + 0.5);
 
                         if (player.Exploration2MarkerProgressTracker == 0)
                         {
@@ -101,7 +101,7 @@ namespace ACE.Server.WorldObjects
                     {
                         player.Exploration3MarkerProgressTracker--;
                         var msg = $"{player.Exploration3MarkerProgressTracker:N0} marker{(player.Exploration3MarkerProgressTracker != 1 ? "s" : "")} remaining.";
-                        player.EarnXP((int)(((-player.Level ?? -1) - 1000) * (PropertyManager.GetDouble("exploration_bonus_xp_markers").Item + 0.5)), XpType.Exploration, null, null, 0, null, ShareType.Fellowship, msg);
+                        player.EarnXP((-player.Level ?? -1) - 1000, XpType.Exploration, null, null, 0, null, ShareType.Fellowship, msg, PropertyManager.GetDouble("exploration_bonus_xp_markers").Item + 0.5);
 
                         if (player.Exploration3MarkerProgressTracker == 0)
                         {

--- a/Source/ACE.Server/WorldObjects/Player_Contracts.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Contracts.cs
@@ -394,39 +394,6 @@ namespace ACE.Server.WorldObjects
             return success;
         }
 
-        public void CheckExplorationLandblock()
-        {
-            var currentLandblock = CurrentLandblock;
-            if (currentLandblock == null)
-                return; // TODO: Fix this - Players may not be getting credit for exploration
-
-            var currentLandblockId = currentLandblock.Id.Raw >> 16;
-
-            if (!Exploration1LandblockReached && Exploration1LandblockId != 0 && Exploration1LandblockId == currentLandblockId)
-            {
-                Exploration1LandblockReached = true;
-                var msg = $"You've reached {GetCurrentLandblockName() ?? "your exploration contract's location"}! {Exploration1KillProgressTracker:N0} kill{(Exploration1KillProgressTracker != 1 ? "s" : "")} remaining and {Exploration1MarkerProgressTracker:N0} marker{(Exploration1MarkerProgressTracker != 1 ? "s" : "")} remaining.";
-                EarnXP((int)(((-Level ?? -1) - 1000) * (PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5)), XpType.Exploration, null, null, 0, null, ShareType.None, msg);
-                PlayParticleEffect(PlayScript.AugmentationUseAttribute, Guid);
-            }
-
-            if (!Exploration2LandblockReached && Exploration2LandblockId != 0 && Exploration2LandblockId == currentLandblockId)
-            {
-                Exploration2LandblockReached = true;
-                var msg = $"You've reached {GetCurrentLandblockName() ?? "your exploration contract's location"}! {Exploration2KillProgressTracker:N0} kill{(Exploration2KillProgressTracker != 1 ? "s" : "")} remaining and {Exploration2MarkerProgressTracker:N0} marker{(Exploration2MarkerProgressTracker != 1 ? "s" : "")} remaining.";
-                EarnXP((int)(((-Level ?? -1) - 1000) * (PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5)), XpType.Exploration, null, null, 0, null, ShareType.None, msg);
-                PlayParticleEffect(PlayScript.AugmentationUseAttribute, Guid);
-            }
-
-            if (!Exploration3LandblockReached && Exploration3LandblockId != 0 && Exploration3LandblockId == currentLandblockId)
-            {
-                Exploration3LandblockReached = true;
-                var msg = $"You've reached {GetCurrentLandblockName() ?? "your exploration contract's location"}! {Exploration3KillProgressTracker:N0} kill{(Exploration3KillProgressTracker != 1 ? "s" : "")} remaining and {Exploration3MarkerProgressTracker:N0} marker{(Exploration3MarkerProgressTracker != 1 ? "s" : "")} remaining.";
-                EarnXP((int)(((-Level ?? -1) - 1000) * (PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5)), XpType.Exploration, null, null, 0, null, ShareType.None, msg);
-                PlayParticleEffect(PlayScript.AugmentationUseAttribute, Guid);
-            }
-        }
-
         public bool TryGiveRandomSalvage(WorldObject giver = null, int tier = 1, float qualityMod = 0.0f)
         {
             var salvage = LootGenerationFactory.CreateRandomLootObjects(tier, qualityMod, TreasureItemCategory.MundaneItem, TreasureItemType_Orig.Salvage);

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -884,7 +884,6 @@ namespace ACE.Server.WorldObjects
 
             CheckMonsters();
             CheckHouse();
-            CheckExplorationLandblock();
 
             EnqueueBroadcastPhysicsState();
 

--- a/Source/ACE.Server/WorldObjects/TreasureMap.cs
+++ b/Source/ACE.Server/WorldObjects/TreasureMap.cs
@@ -348,7 +348,7 @@ namespace ACE.Server.WorldObjects
                             player.EnqueueBroadcastMotion(new Motion(player.CurrentMotionState.Stance));
 
                             var level = Math.Min(player.Level ?? 1, Level ?? 1);
-                            player.EarnXP(-level - 1000, XpType.Exploration, null, null, 0, null, ShareType.None, msg, PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5);
+                            player.EarnXP(-level - 1000, XpType.Exploration, null, null, 0, null, ShareType.None, msg, PropertyManager.GetDouble("exploration_bonus_xp_treasure").Item + 0.5);
 
                             var visibleCreatures = player.PhysicsObj.ObjMaint.GetVisibleObjectsValuesOfTypeCreature();
                             foreach (var creature in visibleCreatures)


### PR DESCRIPTION
* The following properties have been updated:

// Reason: Reaching exploration contract location still uses this modifier and it needs to be increased
* PropertyManager.ModifyDouble("exploration_bonus_xp", 0.5); // previously 0

// Reason: New property for exploration contract treasure
*  PropertyManager.ModifyDouble("exploration_bonus_xp_treasure", 0.5);

* Removed dead method CheckExplorationLandblock()