### PR TITLE
refactor: updated exploration xp logic

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -521,6 +521,7 @@ namespace ACE.Server.Managers
         public const bool SEASON4_PATCH_1_9 = true;
         public const bool SEASON4_PATCH_1_10 = true;
         public const bool SEASON4_PATCH_1_16 = true;
+        public const bool SEASON4_PATCH_1_17 = true;
 
         public static void LoadDefaultProperties()
         {
@@ -971,6 +972,12 @@ namespace ACE.Server.Managers
                         PropertyManager.ModifyDouble("exploration_bonus_xp", 0.5); // previously 0
                         // Reason: New property for exploration contract treasure
                         PropertyManager.ModifyDouble("exploration_bonus_xp_treasure", 0.5); 
+                    }
+
+                    if (SEASON4_PATCH_1_17)
+                    {
+                        // Reason: New property for exploration contract location discovery
+                        PropertyManager.ModifyDouble("exploration_bonus_xp_contract_location", 0.5); 
                     }
                 }
             }
@@ -1525,8 +1532,9 @@ namespace ACE.Server.Managers
                 ("surface_bonus_xp", new(0.25, "Extra xp earned for kills when hunting outside dungeons. 1.0 means 100% more xp.")),
                 ("hot_dungeon_bonus_xp", new(1.0, "Extra xp earned for kills when inside hot dungeons. 1.0 means 100% more xp.")),
                 ("exploration_bonus_xp_markers", new(1.0, "Extra xp earned while completing exploration assignment's marker objectives. 1.0 means 100% more xp.")),
-                ("exploration_bonus_xp_kills", new(2.0, "Extra xp earned while completing exploration assignment's kill objectives. 1.0 means 100% more xp.")),
+                ("exploration_bonus_xp_kills", new(0.5, "Extra xp earned while completing exploration assignment's kill objectives. 1.0 means 100% more xp.")),
                 ("exploration_bonus_xp_treasure", new(0.5, "Extra xp earned while completing exploration treasure map hunting. 1.0 means 100% more xp.")),
+                ("exploration_bonus_xp_contract_location", new(0.5, "Extra xp earned while completing exploration treasure map hunting. 1.0 means 100% more xp.")),
 
                 ("elite_mob_spawn_rate", new(0.00, "Probability of a creature spawning as an elite mob. 1.0 means 100%")),
                 ("elite_mob_loot_quality", new(0.5, "Loot quality mod of elite mob (For reference, normal is 1.0, chests are 1.2, Awareness chests are 1.4")),

--- a/Source/ACE.Server/WorldObjects/GenericObject.cs
+++ b/Source/ACE.Server/WorldObjects/GenericObject.cs
@@ -65,7 +65,7 @@ namespace ACE.Server.WorldObjects
                     {
                         player.Exploration1MarkerProgressTracker--;
                         var msg = $"{player.Exploration1MarkerProgressTracker:N0} marker{(player.Exploration1MarkerProgressTracker != 1 ? "s" : "")} remaining.";
-                        player.EarnXP((-player.Level ?? -1) - 1000, XpType.Exploration, null, null, 0, null, ShareType.Fellowship, msg, PropertyManager.GetDouble("exploration_bonus_xp_markers").Item + 0.5);
+                        player.EarnXP((int)(((-player.Level ?? -1) - 1000) * (PropertyManager.GetDouble("exploration_bonus_xp_markers").Item + 0.5)), XpType.Exploration, null, null, 0, null, ShareType.Fellowship, msg, PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5);
 
                         if (player.Exploration1MarkerProgressTracker == 0)
                         {
@@ -83,7 +83,7 @@ namespace ACE.Server.WorldObjects
                     {
                         player.Exploration2MarkerProgressTracker--;
                         var msg = $"{player.Exploration2MarkerProgressTracker:N0} marker{(player.Exploration2MarkerProgressTracker != 1 ? "s" : "")} remaining.";
-                        player.EarnXP((-player.Level ?? -1) - 1000, XpType.Exploration, null, null, 0, null, ShareType.Fellowship, msg, PropertyManager.GetDouble("exploration_bonus_xp_markers").Item + 0.5);
+                        player.EarnXP((int)(((-player.Level ?? -1) - 1000) * (PropertyManager.GetDouble("exploration_bonus_xp_markers").Item + 0.5)), XpType.Exploration, null, null, 0, null, ShareType.Fellowship, msg, PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5);
 
                         if (player.Exploration2MarkerProgressTracker == 0)
                         {
@@ -101,7 +101,7 @@ namespace ACE.Server.WorldObjects
                     {
                         player.Exploration3MarkerProgressTracker--;
                         var msg = $"{player.Exploration3MarkerProgressTracker:N0} marker{(player.Exploration3MarkerProgressTracker != 1 ? "s" : "")} remaining.";
-                        player.EarnXP((-player.Level ?? -1) - 1000, XpType.Exploration, null, null, 0, null, ShareType.Fellowship, msg, PropertyManager.GetDouble("exploration_bonus_xp_markers").Item + 0.5);
+                        player.EarnXP((int)(((-player.Level ?? -1) - 1000) * (PropertyManager.GetDouble("exploration_bonus_xp_markers").Item + 0.5)), XpType.Exploration, null, null, 0, null, ShareType.Fellowship, msg, PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5);
 
                         if (player.Exploration3MarkerProgressTracker == 0)
                         {

--- a/Source/ACE.Server/WorldObjects/Player_Contracts.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Contracts.cs
@@ -340,7 +340,7 @@ namespace ACE.Server.WorldObjects
 
                 var explorationSite = DatabaseManager.World.GetExplorationSitesByLandblock((ushort)landblockId).FirstOrDefault();
                 var level = explorationSite != null ? Math.Min(explorationSite.Level, Level ?? 1) : Level;
-                EarnXP((-level ?? -1) - 1000, XpType.Exploration, null, null, 0, null, ShareType.None, msg, (PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5) * 3);
+                EarnXP((int)(((-level ?? -1) - 1000) * (PropertyManager.GetDouble("exploration_bonus_xp_contract_location").Item + 0.5)), XpType.Exploration, null, null, 0, null, ShareType.Fellowship, msg, (PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5) * 3);
                 PlayParticleEffect(PlayScript.AugmentationUseAttribute, Guid);
                 if (Exploration1KillProgressTracker == 0 && Exploration1MarkerProgressTracker == 0)
                     Session.Network.EnqueueSend(new GameMessageSystemChat("Your exploration assignment is now fulfilled!", ChatMessageType.Broadcast));
@@ -353,7 +353,7 @@ namespace ACE.Server.WorldObjects
 
                 var explorationSite = DatabaseManager.World.GetExplorationSitesByLandblock((ushort)landblockId).FirstOrDefault();
                 var level = explorationSite != null ? Math.Min(explorationSite.Level, Level ?? 1) : Level;
-                EarnXP((-level ?? -1) - 1000, XpType.Exploration, null, null, 0, null, ShareType.None, msg, (PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5) * 3);
+                EarnXP((int)(((-level ?? -1) - 1000) * (PropertyManager.GetDouble("exploration_bonus_xp_contract_location").Item + 0.5)), XpType.Exploration, null, null, 0, null, ShareType.Fellowship, msg, (PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5) * 3);
                 PlayParticleEffect(PlayScript.AugmentationUseAttribute, Guid);
                 if (Exploration2KillProgressTracker == 0 && Exploration2MarkerProgressTracker == 0)
                     Session.Network.EnqueueSend(new GameMessageSystemChat("Your exploration assignment is now fulfilled!", ChatMessageType.Broadcast));
@@ -366,7 +366,7 @@ namespace ACE.Server.WorldObjects
 
                 var explorationSite = DatabaseManager.World.GetExplorationSitesByLandblock((ushort)landblockId).FirstOrDefault();
                 var level = explorationSite != null ? Math.Min(explorationSite.Level, Level ?? 1) : Level;
-                EarnXP((-level ?? -1) - 1000, XpType.Exploration, null, null, 0, null, ShareType.None, msg, (PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5) * 3);
+                EarnXP((int)(((-level ?? -1) - 1000) * (PropertyManager.GetDouble("exploration_bonus_xp_contract_location").Item + 0.5)), XpType.Exploration, null, null, 0, null, ShareType.Fellowship, msg, (PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5) * 3);
                 PlayParticleEffect(PlayScript.AugmentationUseAttribute, Guid);
                 if (Exploration3KillProgressTracker == 0 && Exploration3MarkerProgressTracker == 0)
                     Session.Network.EnqueueSend(new GameMessageSystemChat("Your exploration assignment is now fulfilled!", ChatMessageType.Broadcast));

--- a/Source/ACE.Server/WorldObjects/Player_Xp.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Xp.cs
@@ -309,7 +309,7 @@ namespace ACE.Server.WorldObjects
                 if (Exploration1LandblockId == CurrentLandblock.Id.Raw >> 16 && Exploration1KillProgressTracker > 0)
                 {
                     Exploration1KillProgressTracker--;
-                    long explorationXP = (long)(m_amount_before_extra * (float)PropertyManager.GetDouble("exploration_bonus_xp_kills").Item);
+                    long explorationXP = (long)((m_amount_before_extra * (PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5)) * (float)PropertyManager.GetDouble("exploration_bonus_xp_kills").Item);
                     xpMessage = $"{Exploration1KillProgressTracker:N0} kill{(Exploration1KillProgressTracker != 1 ? "s" : "")} remaining.";
                     GrantXP(explorationXP, XpType.Exploration, ShareType.None, xpMessage);
 
@@ -323,7 +323,7 @@ namespace ACE.Server.WorldObjects
                 else if (Exploration2LandblockId == CurrentLandblock.Id.Raw >> 16 && Exploration2KillProgressTracker > 0)
                 {
                     Exploration2KillProgressTracker--;
-                    long explorationXP = (long)(m_amount_before_extra * (float)PropertyManager.GetDouble("exploration_bonus_xp_kills").Item);
+                    long explorationXP = (long)((m_amount_before_extra * (PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5)) * (float)PropertyManager.GetDouble("exploration_bonus_xp_kills").Item);
                     xpMessage = $"{Exploration2KillProgressTracker:N0} kill{(Exploration2KillProgressTracker != 1 ? "s" : "")} remaining.";
                     GrantXP(explorationXP, XpType.Exploration, ShareType.None, xpMessage);
 
@@ -337,7 +337,7 @@ namespace ACE.Server.WorldObjects
                 else if (Exploration3LandblockId == CurrentLandblock.Id.Raw >> 16 && Exploration3KillProgressTracker > 0)
                 {
                     Exploration3KillProgressTracker--;
-                    long explorationXP = (long)(m_amount_before_extra * (float)PropertyManager.GetDouble("exploration_bonus_xp_kills").Item);
+                    long explorationXP = (long)((m_amount_before_extra * (PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5)) * (float)PropertyManager.GetDouble("exploration_bonus_xp_kills").Item);
                     xpMessage = $"{Exploration3KillProgressTracker:N0} kill{(Exploration3KillProgressTracker != 1 ? "s" : "")} remaining.";
                     GrantXP(explorationXP, XpType.Exploration, ShareType.None, xpMessage);
 

--- a/Source/ACE.Server/WorldObjects/TreasureMap.cs
+++ b/Source/ACE.Server/WorldObjects/TreasureMap.cs
@@ -348,7 +348,7 @@ namespace ACE.Server.WorldObjects
                             player.EnqueueBroadcastMotion(new Motion(player.CurrentMotionState.Stance));
 
                             var level = Math.Min(player.Level ?? 1, Level ?? 1);
-                            player.EarnXP(-level - 1000, XpType.Exploration, null, null, 0, null, ShareType.None, msg, PropertyManager.GetDouble("exploration_bonus_xp_treasure").Item + 0.5);
+                            player.EarnXP((int)((-level - 1000) * (PropertyManager.GetDouble("exploration_bonus_xp_treasure").Item + 0.5)), XpType.Exploration, null, null, 0, null, ShareType.None, msg, PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5);
 
                             var visibleCreatures = player.PhysicsObj.ObjMaint.GetVisibleObjectsValuesOfTypeCreature();
                             foreach (var creature in visibleCreatures)
@@ -371,7 +371,7 @@ namespace ACE.Server.WorldObjects
                             player.EnqueueBroadcastMotion(new Motion(player.CurrentMotionState.Stance));
 
                             var level = Math.Min(player.Level ?? 1, Level ?? 1);
-                            player.EarnXP(-level - 1000, XpType.Exploration, null, null, 0, null, ShareType.None, "You unearth a treasure chest!", (PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5) * 3);
+                            player.EarnXP((int)((-level - 1000) * (PropertyManager.GetDouble("exploration_bonus_xp_treasure").Item + 0.5)), XpType.Exploration, null, null, 0, null, ShareType.None, "You unearth a treasure chest!", (PropertyManager.GetDouble("exploration_bonus_xp").Item + 0.5) * 3);
 
                             var tier = RollTier(Tier ?? 1);
                             var treasureChest = WorldObjectFactory.CreateNewWorldObject(TreasureChests[tier - 1]);


### PR DESCRIPTION
Updated server properties

   // Reason: New property for exploration contract location discovery
   PropertyManager.ModifyDouble("exploration_bonus_xp_contract_location", 0.5);

* added fix for exploration marker xp
* refactored exploration xp logic to have individual modifiers applied (kills, markers, contract location, and treasure) before the exploration_bonux_xp modifier