### PR TITLE
fix: creature dot hot bug

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_DoT_HoT.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_DoT_HoT.cs
@@ -482,7 +482,7 @@ namespace ACE.Server.WorldObjects
                         sourcePlayer.SendMessage($"Hemorrhage! You {verb} {targetName} with {damage:N0} points of {damageTypeString} damage!", messageType);
                     }
 
-                    if (targetPlayer != null && targetPlayer != sourcePlayer)
+                    if (targetPlayer != null && sourcePlayer != null && targetPlayer != sourcePlayer)
                         targetPlayer.SendMessage($"Hemorrhage! {sourcePlayer.Name} {plural} you with {damage:N0} points of {damageTypeString} damage.", messageType);
                 }
             }


### PR DESCRIPTION
* null check for sourcePlayer when handling hemorrhage messaging to target players