### PR TITLE
feat: add player ghosts from outdoor deaths

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
@@ -236,6 +236,8 @@ namespace ACE.Entity.Enum.Properties
         HasArenaRareDmgBuff = 9302,
         HasArenaRareDmgReductionBuff = 9303,
 
+        /* other */
+        IsGhost = 9401,
     }
 
     public static class PropertyBoolExtensions

--- a/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
@@ -261,6 +261,9 @@ namespace ACE.Entity.Enum.Properties
         ArenaDailyRewardCount = 9303,
         ArenaSameClanDailyRewardCount = 9304,
         LastArenaCommandTimestamp = 9305,
+
+        // Other
+        MinimumTimeSinceGhost = 9401,
     }
 
     public static class PropertyFloatExtensions

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -35,6 +35,7 @@ using ACE.Server.Network.Handlers;
 using Position = ACE.Entity.Position;
 using ACE.Database.Models.Shard;
 using System.Text;
+using ACE.Server.WorldObjects.Managers;
 
 namespace ACE.Server.Command.Handlers;
 
@@ -5699,6 +5700,45 @@ public static class AdminCommands
         var position = new Position((float)(treasureMap.NSCoordinates ?? 0), (float)(treasureMap.EWCoordinates ?? 0f));
 
         session.Player.Teleport(position);
+    }
+
+    [CommandHandler("testghost", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, "toggle ghosting for testing.")]
+    public static void HandleTestGhost(Session session, params string[] parameters)
+    {
+        var player = session.Player;
+        if (parameters.Count() > 0)
+        {
+            var name = string.Join(" ", parameters);
+            var target = PlayerManager.GetAllOnline().FirstOrDefault(p => p.Name.ToLower() == name.ToLower());
+            if (target != null)
+                player = target;
+            else
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"Couldn't find player with name {name.ToLower()}.", ChatMessageType.Help));
+                return;
+            }
+        }
+
+        if (player.IsGhost)
+            player.EndGhost();
+        else
+            player.BeginGhost();
+    }
+    
+    [CommandHandler("endghost", AccessLevel.Admin, CommandHandlerFlag.RequiresWorld, 1, "end ghosting for a player.", "name of player to end ghosting")]
+    public static void HandlEndGhost(Session session, params string[] parameters)
+    {
+        if (parameters.Count() < 1)
+            session.Network.EnqueueSend(new GameMessageSystemChat($"Invalid player name parameter.", ChatMessageType.Help));
+
+        var name = string.Join(" ", parameters);
+
+        var player = PlayerManager.GetAllOnline().FirstOrDefault(p => p.Name.ToLower() == name.ToLower());
+
+        if (player != null)
+            player.EndGhost();
+        else
+            session.Network.EnqueueSend(new GameMessageSystemChat($"Couldn't find player with name {name.ToLower()}.", ChatMessageType.Help));
     }
 }
 

--- a/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/PlayerCommands.cs
@@ -2540,5 +2540,24 @@ namespace ACE.Server.Command.Handlers
 
             session.Player.FixStuckEquippedItemIcon(EquipMask.Shield);
         }
+
+        [CommandHandler("ghost", AccessLevel.Player, CommandHandlerFlag.RequiresWorld, "Displays the remaining time a player has left as a ghost.")]
+        public static void HandleGhostInfo(Session session, params string[] parameters)
+        {
+
+            var player = session.Player;
+            var respite = PropertyManager.GetDouble("ghost_respite_timer").Item;
+            if (player.IsGhost)
+            {
+                var seconds = respite - player.MinimumTimeSinceGhost;
+                var minutes = (int)(seconds / 60);
+                var remainingSeconds = (int)(seconds % 60);
+                var message = $"You have about {(minutes < 1 ? "" : minutes > 1 ? $"{minutes} minutes and " : $"{minutes} minute and " )} {remainingSeconds:D2}second{(remainingSeconds > 1 ? "s" : "")} remaining as a ghost.";
+                session.Network.EnqueueSend(new GameMessageSystemChat(message, ChatMessageType.Broadcast));
+            } else
+            {
+                session.Network.EnqueueSend(new GameMessageSystemChat($"You are not a ghost.", ChatMessageType.Broadcast));
+            }
+        }
     }
 }

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -277,7 +277,7 @@ namespace ACE.Server.Entity
                         float distance;
                         if (Pathfinder.PathfindingEnabled && player.Location.Indoors)
                         {
-                            if(!Pathfinder.GetRouteDistance(player.Location, marker.Location, AgentWidth.Narrow, out distance))
+                            if (!Pathfinder.GetRouteDistance(player.Location, marker.Location, AgentWidth.Narrow, out distance))
                                 distance = player.Location.DistanceTo(marker.Location);
                         }
                         else
@@ -339,7 +339,7 @@ namespace ACE.Server.Entity
                     float distance;
                     if (Pathfinder.PathfindingEnabled && entryPos.Indoors)
                     {
-                        if(!Pathfinder.GetRouteDistance(entryPos, markerOrPortal.Location, AgentWidth.Narrow, out distance))
+                        if (!Pathfinder.GetRouteDistance(entryPos, markerOrPortal.Location, AgentWidth.Narrow, out distance))
                             distance = entryPos.DistanceTo(markerOrPortal.Location);
                     }
                     else
@@ -371,7 +371,7 @@ namespace ACE.Server.Entity
                 {
                     attempts++;
                     explorationMarker.Destroy();
-                    if(attempts < 10)
+                    if (attempts < 10)
                         SpawnExplorationMarker(attempts);
                     else
                         log.Warn($"Landblock 0x{Id} failed to spawn exploration marker.");
@@ -494,7 +494,7 @@ namespace ACE.Server.Entity
 
             if (PropertyManager.GetBool("increase_minimum_encounter_spawn_density").Item)
             {
-                if(!wasCached)
+                if (!wasCached)
                 {
                     if (encounters.Count > 0)
                     {
@@ -576,7 +576,7 @@ namespace ACE.Server.Entity
                 landblockInstances = GetLandblockInstances(true);
                 portalDrops = DatabaseManager.World.GetPortalDestinationsByLandblock(GetAdjacents());
 
-                foreach(var destination in portalDrops)
+                foreach (var destination in portalDrops)
                 {
                     if (!destination.Location.Indoors)
                         destination.Location.AdjustMapCoords();
@@ -618,7 +618,7 @@ namespace ACE.Server.Entity
                     {
                         wo.Destroy();
                         return;
-					}
+                    }
 
                     if (PropertyManager.GetBool("increase_minimum_encounter_spawn_density").Item)
                     {
@@ -1526,7 +1526,7 @@ namespace ACE.Server.Entity
             }
 
             var closest = float.MaxValue;
-            foreach(var entry in RoadList)
+            foreach (var entry in RoadList)
             {
                 if (avoidPosition != null && entry.DistanceTo(avoidPosition) < 2)
                     continue;
@@ -1825,7 +1825,7 @@ namespace ACE.Server.Entity
                 foreach (var lb in Adjacents)
                     lb.FogColor = environChangeType;
 
-                foreach(var player in players)
+                foreach (var player in players)
                 {
                     player.SetFogColor(FogColor);
                 }
@@ -1911,6 +1911,34 @@ namespace ACE.Server.Entity
             return playerList;
         }
 
+        internal Position FindGhostPosition(Position position)
+        {
+            var distSq = 0.0f;          
+            var furthestPos = position;  
+
+            foreach (var adjacent in Adjacents)
+            {
+                foreach (var creature in adjacent.worldObjects.Values.OfType<Creature>())
+                {
+                    var pos = creature.Location;
+                    var objDist = position.SquaredDistanceTo(pos);
+
+                    if (objDist > distSq)
+                    {
+                        distSq = objDist;
+                        furthestPos = pos.InFrontOf(2.0); 
+
+                        if (distSq >= 200000)
+                        {
+                            return furthestPos;
+                        }
+                    }
+                }
+            }
+
+            return furthestPos;
+        }
+
         private bool? _isArenaLandblock = null;
         public bool IsArenaLandblock
         {
@@ -1926,3 +1954,4 @@ namespace ACE.Server.Entity
         }
     }
 }
+

--- a/Source/ACE.Server/Entity/MagicState.cs
+++ b/Source/ACE.Server/Entity/MagicState.cs
@@ -144,6 +144,9 @@ namespace ACE.Server.Entity
             if (Player.UnderLifestoneProtection)
                 Player.LifestoneProtectionDispel();
 
+            if (Player.IsGhost)
+                Player.EndGhost();
+
             CastNum++;
 
             if (Player.RecordCast.Enabled)

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -1208,6 +1208,7 @@ namespace ACE.Server.Managers
                 ("broadcast_player_create", new Property<bool>(false, "enable this to braodcast player creation actions")),
                 ("broadcast_player_restore", new Property<bool>(false, "enable this to braodcast player restoration actions")),
                 ("bz_whispers_enabled", new Property<bool>(true, "CustomDM: Enables/Disables whispers from Bael'Zharon revealing the location of other PK players")),
+                ("ghosting_enabled", new Property<bool>(true, "set to true to enable ghosting on outdoor death feature")),
 
                 // Do not edit below this line
                 ("null_bool", new(false, "No effect, just included here as a last item on the list to prevent related lines from being changed in git upon new property additions."))
@@ -1252,7 +1253,6 @@ namespace ACE.Server.Managers
                 ("bz_whispers_min_pop", new Property<long>(5, "CustomDM: Minimum required online PK players for bz whispers to be sent")),
                 ("bz_whispers_login_delay", new Property<long>(3600, "CustomDM: How long a player must remain online before being able to receive a bz whisper")),
                 ("bz_whispers_interval", new Property<long>(600, "CustomDM: How often a player can receive a bz whisper")),
-
 
                 // Do not edit below this line
                 ("null_long", new(0, "No effect, just included here as a last item on the list to prevent related lines from being changed in git upon new property additions."))
@@ -1614,6 +1614,7 @@ namespace ACE.Server.Managers
                 ("arena_corpse_rot_seconds", new Property<double>(900, "the number of seconds a corpse that is generated in an arena landblock takes to rot. Default 15 mins.")),
                 ("catchup_xp_modifier", new Property<double>(2.0, "Globally scales the amount of xp received by players who are below the previous_max_level threshold, note that this possibly multiplies the other xp_modifier options.")),
                 ("bz_whispers_chance", new Property<double>(0.2, "CustomDM: The chance a player will receive a bz whisper every bz_whispers_interval")),
+                ("ghost_respite_timer", new Property<double>(600, "The number of seconds a player can be in ghost state after death")),
 
                 // Do not edit below this line
                 ("null_double", new(0, "No effect, just included here as a last item on the list to prevent related lines from being changed in git upon new property additions."))

--- a/Source/ACE.Server/WorldObjects/Player_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Awareness.cs
@@ -3,6 +3,7 @@ using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
+using ACE.Server.Managers;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Network.Structure;

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -814,6 +814,9 @@ namespace ACE.Server.WorldObjects
             if (UnderLifestoneProtection)
                 LifestoneProtectionDispel();
 
+            if (!IsInDeathProcess && IsGhost)
+                EndGhost();
+
             HandlePreTeleportVisibility(newPosition);
 
             UpdatePlayerPosition(new Position(newPosition), true);
@@ -887,6 +890,12 @@ namespace ACE.Server.WorldObjects
             CheckHouse();
 
             EnqueueBroadcastPhysicsState();
+
+            if (IsGhost)
+            {
+                SetGhostAnimation();
+                SetBeginGhostProperties();
+            }
 
             // hijacking this for both start/end on portal teleport
             if (LastTeleportStartTimestamp == LastPortalTeleportTimestamp)
@@ -1047,6 +1056,9 @@ namespace ACE.Server.WorldObjects
 
                 if (UnderLifestoneProtection)
                     LifestoneProtectionDispel();
+
+                if (IsGhost)
+                    EndGhost();
 
                 CheckMonsters();
                 CheckHouse();

--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -529,6 +529,9 @@ namespace ACE.Server.WorldObjects
 
             if (UnderLifestoneProtection)
                 LifestoneProtectionDispel();
+
+            if (IsGhost)
+                EndGhost();
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Player_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Missile.cs
@@ -333,6 +333,9 @@ namespace ACE.Server.WorldObjects
 
             if (UnderLifestoneProtection)
                 LifestoneProtectionDispel();
+
+            if (IsGhost)
+                EndGhost();
         }
 
         // TODO: the damage pipeline currently uses the creature ammo instead of the projectile

--- a/Source/ACE.Server/WorldObjects/Player_Move.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Move.cs
@@ -364,7 +364,7 @@ namespace ACE.Server.WorldObjects
 
         public void TakeDamage_Falling(float amount)
         {
-            if (IsDead || Invincible || IsOnNoDamageLandblock) return;
+            if (IsGhost || IsDead || Invincible || IsOnNoDamageLandblock) return;
 
             // handle lifestone protection?
             if (UnderLifestoneProtection)

--- a/Source/ACE.Server/WorldObjects/Player_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Properties.cs
@@ -1752,6 +1752,17 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyFloat.LastArenaCommandTimestamp); else SetProperty(PropertyFloat.LastArenaCommandTimestamp, value.Value); }
         }
 
+        public bool IsGhost
+        {
+            get => GetProperty(PropertyBool.IsGhost) ?? false;
+            set { if (!value) RemoveProperty(PropertyBool.IsGhost); else SetProperty(PropertyBool.IsGhost, value); }
+        }
+
+        public double? MinimumTimeSinceGhost
+        {
+            get => GetProperty(PropertyFloat.MinimumTimeSinceGhost);
+            set { if (!value.HasValue) RemoveProperty(PropertyFloat.MinimumTimeSinceGhost); else SetProperty(PropertyFloat.MinimumTimeSinceGhost, value.Value); }
+        }
 
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Tick.cs
@@ -200,6 +200,8 @@ namespace ACE.Server.WorldObjects
 
             PK_DeathTick();
 
+            GhostTick();
+
             GagsTick();
 
             if (IsArenaObserver)
@@ -253,6 +255,21 @@ namespace ACE.Server.WorldObjects
             }
 
             base.Heartbeat(currentUnixTime);
+        }
+
+        private void GhostTick()
+        {
+            if (MinimumTimeSinceGhost == null)
+                return;
+
+            MinimumTimeSinceGhost += CachedHeartbeatInterval;
+
+            var respiteTimer = PropertyManager.GetDouble("ghost_respite_timer").Item;
+
+            if (MinimumTimeSinceGhost < respiteTimer)
+                return;
+
+            EndGhost();
         }
 
         public static float MaxSpeed = 50;


### PR DESCRIPTION
- Player deaths within outdoor landblocks will become ghosts instead of teleporting to their lifestones.
- Only non-pvp deaths can become ghosts.
- Players that spawn as ghosts, spawn 2 clicks from their corpse and become non-attackable and ethereal.
- Players remain in their ghost state for 5 minutes.
- Players that teleport, engage in combat, or cast spells will exit from their ghost state.
- Added new admin command /testghost for toggling ghost stats for testing
- Added new admin command /endghost to disable ghosting state for an online player
- Added new player command /ghost to display the remaining time a player has left as a ghost